### PR TITLE
Initial gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
 
   call-tests-unit:
     name: Run Unit Tests
-    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@main
+    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@master
     
 #  call-tests-integration:
 #    name: Run Integration Tests
-#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@main
+#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: pass-docker-services Continuous Integration
+on: [ pull_request, workflow_dispatch ]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  call-tests-unit:
+    name: Run Unit Tests
+    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@main
+    
+#  call-tests-integration:
+#    name: Run Integration Tests
+#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@main

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,18 @@
+name: Run Integration Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Run Integration Tests
+        run: go test -tags=integration ./...

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,0 +1,18 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.17.0'
+
+      - name: Run Unit Tests
+        run: go test ./...


### PR DESCRIPTION
Commented out integration tests in `ci.yml` since they don't exist yet. (See pipeline doc https://github.com/eclipse-pass/main/blob/main/docs/deploy/pipeline.md)
```
#  call-tests-integration:
#    name: Run Integration Tests
#    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@master
```