### PR TITLE
Modify how unit tests are called so as not to skip tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Run Unit Tests
     uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-unit.yml@master
     
-#  call-tests-integration:
-#    name: Run Integration Tests
+  call-tests-integration:
+    name: Run Integration Tests
+    run: echo "There currently are no Integration Tests for eclipse-pass/pass-dupe-checker.\nSkipping..."
 #    uses: eclipse-pass/pass-dupe-checker/.github/workflows/tests-integration.yml@master

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -15,4 +15,4 @@ jobs:
           go-version: '>=1.17.0'
 
       - name: Run Unit Tests
-        run: go test
+        run: go test ./...


### PR DESCRIPTION
Currently, the Unit tests (`.github/workflows/tests-unit.yml`) are run with `go test`. This succeeds but skips tests. Running `go test ./...` doesn't skip tests but fails.

I'm opening this PR to use `go test ./...`. It should be safe to merge once https://github.com/eclipse-pass/main/issues/263 has been closed.